### PR TITLE
add a link to additional document

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Download the compiled APK from the [latest release](release/app-release.apk) and
 5. When the keys are loaded, tap your NFC card on the phone to run the key change on the card. 
 Warning! If you lose the keys then you will be unable to reprogram the card again
 
+also see this document - [Steps for making a bolt card with the Android app](https://github.com/boltcard/boltcard/blob/main/docs/CARD_ANDROID.md)
+
 ## Useful commands
 
 * adb logcat -s "lightningnfcapp"


### PR DESCRIPTION
from a comment in the telegram group
it seems to be useful to reference the additional app related document from https://github.com/boltcard/boltcard/
```
In the android app, what's the URL we need to write to the NFC card?
I put my domain like boltcard.example.com but does it require a path afterwards?
```

