### PR TITLE
add TAG_DISCOVERED intent action to the allowlist

### DIFF
--- a/android/app/src/main/java/com/lightningnfcapp/MainActivity.java
+++ b/android/app/src/main/java/com/lightningnfcapp/MainActivity.java
@@ -296,7 +296,7 @@ public class MainActivity extends ReactActivity {
   public void onNewIntent(final Intent intent) {
     // Log.w(TAG, "onNewIntent() action:"+intent.getAction());
     //if intent is not an NDEF discovery then do super and return;
-    if (!intent.getAction().equals("android.nfc.action.NDEF_DISCOVERED")) {
+    if (!intent.getAction().equals("android.nfc.action.NDEF_DISCOVERED") && !intent.getAction().equals("android.nfc.action.TAG_DISCOVERED")) {
       super.onNewIntent(intent);
       return;
     }


### PR DESCRIPTION
This PR resolves issue #19 by allowing the `TAG_DISCOVERED` intent action to be received by the app for processing.