### PR TITLE
[feature] Add option to paste Auth URL to Import Keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-native": "0.68.2",
     "react-native-camera": "^4.2.1",
     "react-native-config": "^1.4.6",
+    "react-native-dialog": "^9.2.2",
     "react-native-paper": "^4.12.4",
     "react-native-permissions": "^3.6.0",
     "react-native-qrcode-scanner": "^1.5.5",

--- a/src/screens/KeyDisplayScreen.js
+++ b/src/screens/KeyDisplayScreen.js
@@ -4,6 +4,7 @@ import { Button, NativeEventEmitter, NativeModules, ScrollView, StyleSheet, Text
 import { useFocusEffect } from '@react-navigation/native';
 import { Card } from 'react-native-paper';
 import Ionicons from 'react-native-vector-icons/Ionicons';
+import Dialog from "react-native-dialog";
 
 
 function KeyDisplayScreen({ route, navigation }) {
@@ -20,6 +21,8 @@ function KeyDisplayScreen({ route, navigation }) {
   const [loading, setLoading] = useState(false);
   const [readyToChangeKeys, setReadyToChangeKeys] = useState(false);
   const [writeKeysOutput, setWriteKeysOutput] = useState();
+  const [promptVisible, setPromptVisible] = useState(false);
+  const [pasteUrlValue, setPasteUrlValue] = useState();
 
   useFocusEffect(
     React.useCallback(() => {
@@ -96,6 +99,10 @@ function KeyDisplayScreen({ route, navigation }) {
             onPress={() => navigation.navigate('ScanScreen')}
             title="Scan QR code from console"
           />
+          <Button
+            onPress={() => setPromptVisible(true)}
+            title="Paste Auth URL from Console"
+          />
         </Card.Content>
       </Card>
      
@@ -126,7 +133,26 @@ function KeyDisplayScreen({ route, navigation }) {
         </Card.Content>
       </Card>
       
-      
+      <Dialog.Container visible={promptVisible}>
+        <Dialog.Title>Enter Auth URL</Dialog.Title>
+        <Dialog.Description>
+          Paste your Auth URL from the console here to import the keys.
+        </Dialog.Description>
+        <Dialog.Input label="Auth URL" onChangeText={setPasteUrlValue} value={pasteUrlValue} />
+        <Dialog.Button
+          label="Cancel"
+          onPress={() => {
+            setPromptVisible(false);
+            setPasteUrlValue();
+          }} />
+        <Dialog.Button
+          label="Continue"
+          onPress={() => {
+            setPromptVisible(false);
+            setPasteUrlValue();
+            navigation.navigate('KeyDisplayScreen', {data: pasteUrlValue, timestamp: Date.now()});
+          }} />
+      </Dialog.Container>
     </ScrollView>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5512,6 +5512,11 @@ react-native-config@^1.4.6:
   resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-1.4.6.tgz#2aefebf4d9cf02831e64bbc1307596bd212f6d42"
   integrity sha512-cSLdOfva2IPCxh6HjHN1IDVW9ratAvNnnAUx6ar2Byvr8KQU7++ysdFYPaoNVuJURuYoAKgvjab8ZcnwGZIO6Q==
 
+react-native-dialog@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/react-native-dialog/-/react-native-dialog-9.2.2.tgz#f16921dd071d17daf1e5d98fb084e1837694f009"
+  integrity sha512-d2w3fyqB6G8Os0DYJKnfVl6PgqQwplW8dHSvzkQpczXzmX5V4BXOJTTXqoiKwI+nsS6QEHYb6Bk8VG7vV9WuXQ==
+
 react-native-gradle-plugin@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.6.tgz"


### PR DESCRIPTION
This PR adds a button that enables the user to paste the Auth URL to import keys instead of the QR code. This is helpful for users who are using the same Android device to configure their Bolt Card (via LNBits, for example) and write to their card with this app.

Some crappy pictures of the app because I'm too lazy to figure out screenshots

![IMG_4511](https://user-images.githubusercontent.com/3018359/187259066-685399d6-c5a2-41e4-a452-9bcea97d12f7.jpg)

![IMG_4512](https://user-images.githubusercontent.com/3018359/187259162-a6a60c52-afa0-448d-92ae-78b25b55d688.jpg)
