### PR TITLE
Introduce BoltCardWrapper to support both INTAG424DNA and INTAG424DNATT

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Download the compiled APK from the [latest release](https://github.com/boltcard/
 1. Install [boltcard server](https://github.com/boltcard/boltcard) and aquire some blank NTAG424DNA tags. 
 2. When app has loaded go to the write screen and put your lnurlw domain and path in to the text box.
 3. When finished tap a card on the NFC scanner to write the card.
-4. Go to the read screen and check that your URL looks correct. Should also be outputting the PICC and CMAC as URL paramters
+4. Go to the read screen and check that your URL looks correct. Should also be outputting the PICC and CMAC as URL parameters
 5. To change your keys (to prevent malicious re-writing of your card) Go to the boltcard server terminal and run the command to show the card key change URL in QR code form and then scan this with the phone camera to load the server keys.
 6. When the keys are loaded, Hold the NFC card to the phone to run the key change on the card. Do not move the card until the key change has completed. 
 Warning! If you lose the new keys then you will be unable to reprogram the card again

--- a/android/app/src/main/java/com/lightningnfcapp/BoltCardWrapper.java
+++ b/android/app/src/main/java/com/lightningnfcapp/BoltCardWrapper.java
@@ -1,0 +1,165 @@
+package com.lightningnfcapp;
+
+import com.nxp.nfclib.NxpNfcLib;
+import com.nxp.nfclib.CardType;
+import com.nxp.nfclib.defaultimpl.KeyData;
+import com.nxp.nfclib.desfire.DESFireFactory;
+import com.nxp.nfclib.desfire.INTAG424DNA;
+import com.nxp.nfclib.desfire.INTAG424DNATT;
+import com.nxp.nfclib.desfire.NTAG424DNAFileSettings;
+import com.nxp.nfclib.desfire.NTAG424DNATTFileSettings;
+import com.nxp.nfclib.desfire.MFPCard;
+import com.nxp.nfclib.interfaces.ICard;
+import com.nxp.nfclib.ndef.INdefOperations;
+import com.nxp.nfclib.ndef.INdefMessage;
+import com.nxp.nfclib.ndef.INdefMessage;
+
+public class BoltCardWrapper {
+
+    private INTAG424DNA ntag424DNA = null;
+    private INTAG424DNATT ntag424DNATT = null;
+    private ICard iCard = null;
+    private INdefOperations iNdefOperations = null;
+
+
+    public BoltCardWrapper(NxpNfcLib libInstance, CardType type)
+    {
+        if (type == CardType.NTAG424DNA) {
+            this.ntag424DNA = DESFireFactory.getInstance().getNTAG424DNA(libInstance.getCustomModules());
+            this.iCard = this.ntag424DNA;
+            this.iNdefOperations = this.ntag424DNA;
+
+        }
+        else {
+            this.ntag424DNATT = DESFireFactory.getInstance().getNTAG424DNATT(libInstance.getCustomModules());
+            this.iCard = this.ntag424DNATT;
+            this.iNdefOperations = this.ntag424DNATT;
+        }
+    }
+
+    public CardType getType()
+    {
+        return this.iCard.getType();
+    }
+
+    public byte[] getUID()
+    {
+        return this.iCard.getUID();
+    }
+
+    public int getTotalMemory()
+    {
+        return this.iCard.getTotalMemory();
+    }
+
+    public INdefMessage readNDEF()
+    {
+        return this.iNdefOperations.readNDEF();
+    }
+
+    public void writeNDEF(INdefMessage ndefMsg)
+    {
+        this.iNdefOperations.writeNDEF(ndefMsg);
+    }
+
+    public byte[] getVersion()
+    {
+        if (this.ntag424DNA != null) {
+            return this.ntag424DNA.getVersion();
+        }
+        return this.ntag424DNATT.getVersion();
+    }
+
+    public byte[] isoSelectApplicationByDFName(byte[] dfName)
+    {
+        if (this.ntag424DNA != null) {
+            return this.ntag424DNA.isoSelectApplicationByDFName(dfName);
+        }
+        return this.ntag424DNATT.isoSelectApplicationByDFName(dfName);
+    }
+
+    public void authenticateEV2First(int cardKeyNumber, KeyData key, byte[] pCDcap2)
+    {
+        if (this.ntag424DNA != null) {
+            this.ntag424DNA.authenticateEV2First(cardKeyNumber, key, pCDcap2);
+        }
+        else {
+            this.ntag424DNATT.authenticateEV2First(cardKeyNumber, key, pCDcap2);
+        }
+    }
+
+    public byte getKeyVersion(int keyNumber)
+    {
+        if (this.ntag424DNA != null) {
+            return this.ntag424DNA.getKeyVersion(keyNumber);
+        }
+        return this.ntag424DNATT.getKeyVersion(keyNumber);
+    }
+
+    public void changeKey(int keyNumber, byte[] currentKeyData, byte[] newKeyData, byte newKeyVersion)
+    {
+        if (this.ntag424DNA != null) {
+            this.ntag424DNA.changeKey(keyNumber, currentKeyData, newKeyData, newKeyVersion);
+        }
+        else {
+            this.ntag424DNATT.changeKey(keyNumber, currentKeyData, newKeyData, newKeyVersion);
+        }
+    }
+
+    public void setAndChangeFileSettings(int piccOffset, int macOffset)
+    {
+        if (this.ntag424DNA != null) {
+
+            NTAG424DNAFileSettings fileSettings = new NTAG424DNAFileSettings(
+                    MFPCard.CommunicationMode.Plain,
+                    (byte) 0xE,
+                    (byte) 0xE,
+                    (byte) 0xE,
+                    (byte) 0x0
+            );
+
+            fileSettings.setSdmAccessRights(new byte[] {(byte) 0xFF, (byte) 0x12});
+            fileSettings.setSDMEnabled(true);
+            fileSettings.setUIDMirroringEnabled(true);
+            fileSettings.setSDMReadCounterEnabled(true);
+            fileSettings.setSDMReadCounterLimitEnabled(false);
+            fileSettings.setSDMEncryptFileDataEnabled(false);
+            fileSettings.setUidOffset(null);
+            fileSettings.setSdmReadCounterOffset(null);
+            fileSettings.setPiccDataOffset(new byte[] {(byte) piccOffset, (byte) 0, (byte) 0});
+            fileSettings.setSdmMacInputOffset(new byte[] {(byte) macOffset, (byte) 0, (byte) 0});
+            fileSettings.setSdmEncryptionOffset(null);
+            fileSettings.setSdmEncryptionLength(null);
+            fileSettings.setSdmMacOffset(new byte[] {(byte) macOffset, (byte) 0, (byte) 0});
+            fileSettings.setSdmReadCounterLimit(null);
+
+            this.ntag424DNA.changeFileSettings(2, fileSettings);
+        }
+        else {
+            NTAG424DNATTFileSettings fileSettings = new NTAG424DNATTFileSettings(
+                    MFPCard.CommunicationMode.Plain,
+                    (byte) 0xE,
+                    (byte) 0xE,
+                    (byte) 0xE,
+                    (byte) 0x0
+            );
+
+            fileSettings.setSdmAccessRights(new byte[] {(byte) 0xFF, (byte) 0x12});
+            fileSettings.setSDMEnabled(true);
+            fileSettings.setUIDMirroringEnabled(true);
+            fileSettings.setSDMReadCounterEnabled(true);
+            fileSettings.setSDMReadCounterLimitEnabled(false);
+            fileSettings.setSDMEncryptFileDataEnabled(false);
+            fileSettings.setUidOffset(null);
+            fileSettings.setSdmReadCounterOffset(null);
+            fileSettings.setPiccDataOffset(new byte[] {(byte) piccOffset, (byte) 0, (byte) 0});
+            fileSettings.setSdmMacInputOffset(new byte[] {(byte) macOffset, (byte) 0, (byte) 0});
+            fileSettings.setSdmEncryptionOffset(null);
+            fileSettings.setSdmEncryptionLength(null);
+            fileSettings.setSdmMacOffset(new byte[] {(byte) macOffset, (byte) 0, (byte) 0});
+            fileSettings.setSdmReadCounterLimit(null);
+
+            this.ntag424DNATT.changeFileSettings(2, fileSettings);
+        }
+    }
+}

--- a/src/screens/HelpScreen.js
+++ b/src/screens/HelpScreen.js
@@ -25,7 +25,7 @@ export default function HelpScreen({ navigation }) {
                     3. When finished tap a card on the NFC scanner to write the card.
                 </Text>
                 <Text style={styles.paragraph}>
-                    4. Go to the read screen and check that your URL looks correct. Should also be outputting the PICC and CMAC as URL paramters
+                    4. Go to the read screen and check that your URL looks correct. Should also be outputting the PICC and CMAC as URL parameters
                 </Text>
                 <Text style={styles.paragraph}>
                     5. To change your keys (to prevent malicious re-writing of your card) Go to the boltcard server terminal and run the command to show the card key change URL in QR code form and then scan this with the phone camera to load the server keys.


### PR DESCRIPTION
My Java is a bit rusty, but after googling it seems that I either have to wrap identical methods of 2 separate classes or use introspection. The latter seemed even less attractive. In this MR I chose to wrap the identical methods of  INTAG424DNA and INTAG424DNATT so both card type scan be scanned and written to.


