### PR TITLE
Fix for boltcard bricking caused by false version assumptions

### DIFF
--- a/src/components/ResetBoltcard.js
+++ b/src/components/ResetBoltcard.js
@@ -81,7 +81,7 @@ export default function SetupBoltcard({url}) {
       }
       const json = await response.json();
       console.log(json);
-      const {K0, K1, K2, K3, K4, version} = json;
+      const {K0, K1, K2, K3, K4, version=0} = json;
       if (!K0 || !K1 || !K2 || !K3 || !K4) {
         throw new Error('Error fetching the keys');
       }

--- a/src/components/ResetBoltcard.js
+++ b/src/components/ResetBoltcard.js
@@ -81,10 +81,13 @@ export default function SetupBoltcard({url}) {
       }
       const json = await response.json();
       console.log(json);
-      const {K0, K1, K2, K3, K4} = json;
+      const {K0, K1, K2, K3, K4, version} = json;
       if (!K0 || !K1 || !K2 || !K3 || !K4) {
         throw new Error('Error fetching the keys');
       }
+      let versionhexstr = version.toString(16);
+      if (versionhexstr.length > 2) throw new Error('version out of range'); //check fits into one byte
+      versionhexstr = versionhexstr.padStart(2, '0');
 
       setWritingCard(true);
       setStep(SetupStep.WritingCard);
@@ -97,17 +100,17 @@ export default function SetupBoltcard({url}) {
       await Ntag424.resetFileSettings();
 
       //change keys
-      await Ntag424.changeKey('01', K1, defaultKey, '00');
+      await Ntag424.changeKey('01', K1, defaultKey, versionhexstr);
       result.push('Change Key1: Success');
       console.log('changekey 2');
-      await Ntag424.changeKey('02', K2, defaultKey, '00');
+      await Ntag424.changeKey('02', K2, defaultKey, versionhexstr);
       result.push('Change Key2: Success');
       console.log('changekey 3');
-      await Ntag424.changeKey('03', K3, defaultKey, '00');
+      await Ntag424.changeKey('03', K3, defaultKey, versionhexstr);
       result.push('Change Key3: Success');
-      await Ntag424.changeKey('04', K4, defaultKey, '00');
+      await Ntag424.changeKey('04', K4, defaultKey, versionhexstr);
       result.push('Change Key4: Success');
-      await Ntag424.changeKey('00', K0, defaultKey, '00');
+      await Ntag424.changeKey('00', K0, defaultKey, versionhexstr);
       result = ['Change Key0: Success', ...result];
 
       const message = [Ndef.uriRecord('')];

--- a/src/components/SetupBoltcard.js
+++ b/src/components/SetupBoltcard.js
@@ -110,7 +110,7 @@ export default function SetupBoltcard({url}) {
       }
       const json = await response.json();
       console.log(json);
-      const {K0, K1, K2, K3, K4, LNURLW: lnurlw_base, version} = json;
+      const {K0, K1, K2, K3, K4, LNURLW: lnurlw_base, version=1} = json;
       if (!K0 || !K1 || !K2 || !K3 || !K4 || !lnurlw_base) {
         throw new Error('Error fetching the keys');
       }

--- a/src/components/SetupBoltcard.js
+++ b/src/components/SetupBoltcard.js
@@ -110,10 +110,13 @@ export default function SetupBoltcard({url}) {
       }
       const json = await response.json();
       console.log(json);
-      const {K0, K1, K2, K3, K4, LNURLW: lnurlw_base} = json;
+      const {K0, K1, K2, K3, K4, LNURLW: lnurlw_base, version} = json;
       if (!K0 || !K1 || !K2 || !K3 || !K4 || !lnurlw_base) {
         throw new Error('Error fetching the keys');
       }
+      let versionhexstr = version.toString(16);
+      if (versionhexstr.length > 2) throw new Error('version out of range'); //check fits into one byte
+      versionhexstr = versionhexstr.padStart(2, '0');
 
       setWritingCard(true);
       setStep(SetupStep.WritingCard);
@@ -137,19 +140,19 @@ export default function SetupBoltcard({url}) {
       await Ntag424.setBoltCardFileSettings(piccOffset, macOffset);
       //change keys
       console.log('changekey 1');
-      await Ntag424.changeKey('01', key0, K1, '01');
+      await Ntag424.changeKey('01', key0, K1, versionhexstr);
       setKey1Changed(true);
       console.log('changekey 2');
-      await Ntag424.changeKey('02', key0, K2, '01');
+      await Ntag424.changeKey('02', key0, K2, versionhexstr);
       setKey2Changed(true);
       console.log('changekey 3');
-      await Ntag424.changeKey('03', key0, K3, '01');
+      await Ntag424.changeKey('03', key0, K3, versionhexstr);
       setKey3Changed(true);
       console.log('changekey 4');
-      await Ntag424.changeKey('04', key0, K4, '01');
+      await Ntag424.changeKey('04', key0, K4, versionhexstr);
       setKey4Changed(true);
       console.log('changekey 0');
-      await Ntag424.changeKey('00', key0, K0, '01');
+      await Ntag424.changeKey('00', key0, K0, versionhexstr);
       setKey0Changed(true);
       setWriteKeys('success');
 


### PR DESCRIPTION
This is a fix for boltcard bricking caused by false assumption that a setup is always version number 1 and a reset is aways version number 0.