### PR TITLE
Use key version to prevent a setup bricking an already setup card

### DIFF
--- a/src/components/ResetBoltcard.js
+++ b/src/components/ResetBoltcard.js
@@ -63,6 +63,10 @@ export default function SetupBoltcard({url}) {
 
       const ndefMessage = Ndef.uri.decodePayload(tag.ndefMessage[0].payload);
 
+      await Ntag424.isoSelectFileApplication();
+      const key1Version = await Ntag424.getKeyVersion("01");
+      if (key1Version == '00') throw new Error('YOUR CARD IS ALREADY RESET!');
+
       setStep(SetupStep.RequestingKeys);
       const response = await fetch(url, {
         method: 'POST',

--- a/src/components/SetupBoltcard.js
+++ b/src/components/SetupBoltcard.js
@@ -84,6 +84,10 @@ export default function SetupBoltcard({url}) {
       let uid = tag?.id;
       setCardUID(uid ? uid : '');
 
+      await Ntag424.isoSelectFileApplication();
+      const key1Version = await Ntag424.getKeyVersion("01");
+      if (key1Version != '00') throw new Error('TRY AGAIN AFTER RESETING YOUR CARD!');
+
       const key0 = '00000000000000000000000000000000';
       if(byteSize(uid) == 8) {
         //random uid

--- a/src/screens/CreateBoltcardScreen.js
+++ b/src/screens/CreateBoltcardScreen.js
@@ -85,6 +85,10 @@ export default function CreateBoltcardScreen({route}) {
         alertMessage: "Ready to write card. Hold NFC card to phone until all keys are changed."
       });
 
+      await Ntag424.isoSelectFileApplication();
+      const key1Version = await Ntag424.getKeyVersion("01");
+      if (key1Version != '00') throw new Error('TRY AGAIN AFTER RESETING YOUR CARD!');
+
       //set ndef
       const ndefMessage = lnurlw_base.includes('?')
         ? lnurlw_base + '&p=00000000000000000000000000000000&c=0000000000000000'

--- a/src/screens/ResetKeysScreen.js
+++ b/src/screens/ResetKeysScreen.js
@@ -89,6 +89,10 @@ export default function ResetKeysScreen({route}) {
         alertMessage: "Ready to write card. Hold NFC card to phone until all keys are changed."
       });
       
+      await Ntag424.isoSelectFileApplication();
+      const key1Version = await Ntag424.getKeyVersion("01");
+      if (key1Version == '00') throw new Error('YOUR CARD IS ALREADY RESET!');
+
       const defaultKey = '00000000000000000000000000000000';
       
       // //auth first     

--- a/src/screens/TestScreen.js
+++ b/src/screens/TestScreen.js
@@ -75,6 +75,10 @@ export default function TestScreen({navigation}) {
       await NfcManager.requestTechnology(NfcTech.IsoDep);
       // the resolved tag object will contain `ndefMessage` property
 
+      await Ntag424.isoSelectFileApplication();
+      const key1Version = await Ntag424.getKeyVersion("01");
+      if (key1Version != '00') throw new Error('TRY AGAIN AFTER RESETING YOUR CARD!');
+
       //have to auth with key 0
       const key0 = '00000000000000000000000000000000';
       const {sesAuthEncKey, sesAuthMacKey, ti} = await Ntag424.AuthEv2First(
@@ -130,6 +134,10 @@ export default function TestScreen({navigation}) {
       // register for the NFC tag with NDEF in it
       await NfcManager.requestTechnology(NfcTech.IsoDep);
       // the resolved tag object will contain `ndefMessage` property
+
+      await Ntag424.isoSelectFileApplication();
+      const key1Version = await Ntag424.getKeyVersion("01");
+      if (key1Version == '00') throw new Error('YOUR CARD IS ALREADY RESET!');
 
       //have to auth with key 0
       const defaultkey = '00000000000000000000000000000000';


### PR DESCRIPTION
This is a pull request to test a fix to prevent the boltcard creator app bricking already setup cards when attempting to setup again. The fix rejects a setup and passes on a message to reset a card first.

Also card will be rejected for reset that are already reset, as determined by key version

I will update after receiving new boltcards for testing. All my existing cards are bricked.

See https://github.com/boltcard/bolt-nfc-android-app/issues/45

There  is side loadable release of this version at https://github.com/johnheenan/bolt-nfc-android-app/releases/tag/v0.3.3