### PR TITLE
Bump crypto-js 4.1.1 → 4.2.0 (CVE-2023-46233)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightningnfcapp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightningnfcapp",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "hasInstallScript": true,
       "dependencies": {
         "@react-native-clipboard/clipboard": "^1.10.0",
@@ -16,7 +16,7 @@
         "buffer": "^6.0.3",
         "constants-browserify": "^1.0.0",
         "crc": "^4.3.2",
-        "crypto-js": "^4.1.1",
+        "crypto-js": "^4.2.0",
         "events": "^1.1.1",
         "process": "^0.11.10",
         "react": "18.2.0",
@@ -7085,9 +7085,10 @@
       }
     },
     "node_modules/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "deprecated": "Active development of CryptoJS has been discontinued. This library is no longer maintained."
     },
     "node_modules/css-in-js-utils": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "buffer": "^6.0.3",
     "constants-browserify": "^1.0.0",
     "crc": "^4.3.2",
-    "crypto-js": "^4.1.1",
+    "crypto-js": "^4.2.0",
     "events": "^1.1.1",
     "process": "^0.11.10",
     "react": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3195,10 +3195,10 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto-js@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz"
-  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
+crypto-js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 css-in-js-utils@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
## What

Bumps `crypto-js` from **4.1.1 → 4.2.0** in `package.json`, `package-lock.json` and `yarn.lock`.

## Why

`crypto-js < 4.2.0` is affected by [CVE-2023-46233](https://github.com/advisories/GHSA-46rf-rjw5-3qc4) (CVSS 9.1): `PBKDF2` defaults to **SHA1 with 1 iteration**. 4.2.0 changes the defaults to SHA256 with 250,000 iterations.

## Runtime impact: none

This repo never calls `CryptoJS.PBKDF2`. Usage is confined to NTAG424 DNA card authentication in `src/class/Ntag424.js` and `src/utils/Cmac.js` — AES-CBC/ECB with `NoPadding`, plus CMAC session-key derivation. So this bump only clears the advisory; it changes no behaviour.

## Verified safe

I diffed the two published tarballs. `aes.js` and `evpkdf.js` are **byte-identical** between 4.1.1 and 4.2.0 — the only functional change in the release is `pbkdf2.js`:

```diff
-    hasher: SHA1,
-    iterations: 1
+    hasher: SHA256,
+    iterations: 250000
```

Nothing currently encrypted or authenticated by this app changes.

## Note on `CryptoJS.lib.WordArray`

`Ntag424.js` references `CryptoJS.lib.WordArray` — the same symbol named in the recent **Ill Bloom** advisory. It is used here as `.init()` to build word arrays for an XOR during session-key derivation, **not** `.random()`, so it is unaffected.

For the record: [CVE-2026-71851 / "Ill Bloom"](https://github.com/advisories/GHSA-rg76-677x-56q9) — the weak-RNG issue where `WordArray.random()` collapses 128/256-bit requests to ~2³⁹/2⁴⁷ — affects `crypto-js < 4.0.0` **only**. This repo has always been on 4.x and was never exposed.

## Incidental

`package-lock.json`'s recorded project version was resynced `0.3.2 → 0.3.3` to match `package.json`. That drift pre-existed this change; npm corrected it when regenerating the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9eFm5MqyhJZvzN2tNopAU